### PR TITLE
Fix chinese tags in static output

### DIFF
--- a/src/app/(base)/blog/[slug]/layout.tsx
+++ b/src/app/(base)/blog/[slug]/layout.tsx
@@ -87,7 +87,6 @@ function Footer({ page }: { page: InferPageType<typeof blog> }) {
             key={tag}
             href={getTagHref(tag)}
             className="rounded-md bg-primary/10 px-1 py-0.5 text-sm text-primary"
-            prefetch={false}
           >
             # {tag}
           </Link>

--- a/src/app/(base)/blog/tags/[tag]/page.tsx
+++ b/src/app/(base)/blog/tags/[tag]/page.tsx
@@ -6,7 +6,7 @@ import { domain } from "@config";
 import type { Metadata } from "next";
 
 export default function TagPage({ params }: { params: { tag: string } }) {
-  const decodedTag = decodeURIComponent(params.tag).toLowerCase();
+  const decodedTag = decodeURIComponent(params.tag);
   const pages = blog
     .getPages()
     .filter((blog) =>
@@ -35,7 +35,7 @@ export function generateStaticParams() {
   const tags = [...getTags().keys()];
 
   return tags.map((key) => ({
-    tag: encodeURIComponent(key.toLowerCase()),
+    tag: key.toLowerCase(),
   }));
 }
 


### PR DESCRIPTION
Seems the behaviours of handling dynamic routes in development mode is a little bit different from static output