### PR TITLE
fix: invite redirect not working

### DIFF
--- a/_redirects
+++ b/_redirects
@@ -1,0 +1,1 @@
+/invite https://app.yeecord.com/invite 308


### PR DESCRIPTION
fix invite redirect not working in official Discord server