### PR TITLE
add self-service invite page with permission picker

### DIFF
--- a/config.ts
+++ b/config.ts
@@ -60,8 +60,7 @@ export const footer: FooterCategory[] = [
       },
       {
         label: "邀請機器人",
-        href: "https://app.yeecord.com/invite",
-        newWindow: true,
+        href: "/invite",
       },
       {
         label: "Discord",

--- a/public/_redirects
+++ b/public/_redirects
@@ -1,6 +1,5 @@
-/invite https://app.yeecord.com/invite 302
-/i https://app.yeecord.com/invite 302
-/link https://app.yeecord.com/invite 302
+/i /invite 302
+/link /invite 302
 /discord https://discord.gg/yeecord 302
 /support https://discord.gg/yeecord 302
 /tos /terms 302

--- a/src/app.css
+++ b/src/app.css
@@ -3,6 +3,10 @@
 @import "fumadocs-ui/css/preset.css";
 @import "fumapress/css/preset.css";
 
+@theme {
+  --color-discord-blurple: #5865f2;
+}
+
 :root {
   --default-font-family: "Noto Sans TC", sans-serif;
 

--- a/src/components/invite/picker.tsx
+++ b/src/components/invite/picker.tsx
@@ -1,17 +1,8 @@
 "use client";
 
-import {
-  AudioLines,
-  Check,
-  Server,
-  ShieldCheck,
-  Sparkles,
-  Ticket,
-  Trash2,
-  User,
-  UsersRound,
-} from "lucide-react";
+import { Check, Server, User } from "lucide-react";
 import { useState, type ReactNode } from "react";
+import { buttonVariants } from "@/components/ui/button";
 import { cn } from "@/utils/cn";
 
 const CLIENT_ID = "584213384409382953";
@@ -38,7 +29,6 @@ const requiredBits =
 
 interface Feature {
   id: string;
-  icon: ReactNode;
   title: string;
   description: string;
   permissions: { name: string; bit: bigint }[];
@@ -47,7 +37,6 @@ interface Feature {
 const features: Feature[] = [
   {
     id: "voice",
-    icon: <AudioLines />,
     title: "動態語音頻道",
     description: "有人進語音就開一間專屬房間，人走了自動收。",
     permissions: [
@@ -58,21 +47,18 @@ const features: Feature[] = [
   },
   {
     id: "roles",
-    icon: <UsersRound />,
     title: "身分組",
     description: "新成員進來自動發，或讓成員自己按按鈕領。",
     permissions: [{ name: "管理身分組", bit: 1n << 28n }],
   },
   {
     id: "messages",
-    icon: <Trash2 />,
     title: "訊息管理",
     description: "洗版訊息一次清掉，最多一千則。",
     permissions: [{ name: "管理訊息", bit: 1n << 13n }],
   },
   {
     id: "ticket",
-    icon: <Ticket />,
     title: "私人頻道",
     description: "成員按一顆按鈕，就能私下找管理員。",
     permissions: [
@@ -83,7 +69,6 @@ const features: Feature[] = [
   },
   {
     id: "defense",
-    icon: <ShieldCheck />,
     title: "機器人防禦",
     description: "廣告機器人一發言就封鎖，詐騙圖片自動攔下。",
     permissions: [
@@ -108,14 +93,21 @@ function inviteUrl(mode: "guild" | "user", selected: Set<string>) {
   return `https://discord.com/oauth2/authorize?client_id=${CLIENT_ID}&scope=bot+applications.commands&permissions=${bits}`;
 }
 
-function Chip({ muted, children }: { muted?: boolean; children: ReactNode }) {
+function Chip({
+  muted,
+  className,
+  children,
+}: {
+  muted?: boolean;
+  className?: string;
+  children: ReactNode;
+}) {
   return (
     <span
       className={cn(
-        "rounded-md border px-2 py-0.5 text-xs transition-colors",
-        muted
-          ? "border-fd-border/50 text-fd-muted-foreground/50"
-          : "text-fd-muted-foreground",
+        "rounded-md bg-fd-muted px-2 py-0.5 text-fd-muted-foreground text-xs transition-colors",
+        muted && "opacity-50",
+        className,
       )}
     >
       {children}
@@ -123,10 +115,17 @@ function Chip({ muted, children }: { muted?: boolean; children: ReactNode }) {
   );
 }
 
-function IconTile({ children }: { children: ReactNode }) {
+function Checkbox({ checked }: { checked: boolean }) {
   return (
-    <span className="flex size-10 shrink-0 items-center justify-center rounded-lg bg-gradient-to-br from-green-400/15 to-cyan-500/15 text-green-500 [&_svg]:size-5 dark:text-green-400">
-      {children}
+    <span
+      className={cn(
+        "flex size-5 shrink-0 items-center justify-center rounded-md border transition-colors",
+        checked
+          ? "border-green-600 bg-green-600 text-white dark:border-green-500 dark:bg-green-500"
+          : "border-fd-border bg-fd-background",
+      )}
+    >
+      {checked && <Check className="size-3.5" strokeWidth={3} />}
     </span>
   );
 }
@@ -149,8 +148,8 @@ export function InvitePicker() {
   }
 
   return (
-    <div className="flex flex-col gap-8">
-      <div className="mx-auto flex rounded-full border bg-fd-muted/50 p-1 text-sm font-medium">
+    <div className="flex flex-col gap-6">
+      <div className="mx-auto flex rounded-lg border bg-fd-muted/50 p-1 font-medium text-sm">
         {(
           [
             ["guild", <Server key="i" className="size-4" />, "裝進伺服器"],
@@ -162,7 +161,7 @@ export function InvitePicker() {
             type="button"
             onClick={() => setMode(value)}
             className={cn(
-              "flex items-center gap-2 rounded-full px-5 py-2 transition-all",
+              "flex items-center gap-2 rounded-md px-5 py-2 transition-colors",
               mode === value
                 ? "bg-fd-background text-fd-foreground shadow-sm"
                 : "text-fd-muted-foreground hover:text-fd-foreground",
@@ -176,31 +175,24 @@ export function InvitePicker() {
 
       {mode === "guild" ? (
         <>
-          <div className="rounded-2xl border bg-fd-card/60 p-6 backdrop-blur">
-            <div className="flex items-start gap-4">
-              <IconTile>
-                <Sparkles />
-              </IconTile>
-              <div className="min-w-0">
-                <div className="flex flex-wrap items-center gap-3">
-                  <h2 className="font-semibold text-lg">必要權限</h2>
-                  <span className="rounded-full bg-green-400/10 px-2.5 py-0.5 text-xs font-medium text-green-500 dark:text-green-400">
-                    一定要帶
-                  </span>
-                </div>
-                <p className="mt-1 text-sm text-fd-muted-foreground">
-                  看得到頻道、說得了話。少了這些，機器龍進來也只能當雕像。
-                </p>
-                <div className="mt-3 flex flex-wrap gap-1.5">
-                  {requiredPermissions.map((permission) => (
-                    <Chip key={permission}>{permission}</Chip>
-                  ))}
-                </div>
-              </div>
+          <div className="rounded-xl border bg-fd-card p-5">
+            <div className="flex flex-wrap items-center gap-2">
+              <h2 className="font-semibold">必要權限</h2>
+              <span className="text-fd-muted-foreground text-xs">
+                一定要帶
+              </span>
+            </div>
+            <p className="mt-1 text-fd-muted-foreground text-sm">
+              看得到頻道、說得了話。少了這些，機器龍進來也只能當雕像。
+            </p>
+            <div className="mt-3 flex flex-wrap gap-1.5">
+              {requiredPermissions.map((permission) => (
+                <Chip key={permission}>{permission}</Chip>
+              ))}
             </div>
           </div>
 
-          <div className="grid gap-4 sm:grid-cols-2">
+          <div className="grid gap-3 sm:grid-cols-2">
             {features.map((feature) => {
               const checked = selected.has(feature.id);
 
@@ -211,44 +203,32 @@ export function InvitePicker() {
                   onClick={() => toggle(feature.id)}
                   aria-pressed={checked}
                   className={cn(
-                    "group relative rounded-2xl border p-6 text-left transition-all duration-200",
+                    "rounded-xl border p-5 text-left transition-colors",
                     checked
-                      ? "border-green-400/40 bg-gradient-to-br from-green-400/[0.07] to-cyan-500/[0.07] shadow-[0_0_30px_-12px] shadow-green-400/40"
-                      : "bg-fd-card/40 hover:border-fd-muted-foreground/30",
+                      ? "bg-fd-card"
+                      : "bg-fd-card/50 hover:bg-fd-card",
                   )}
                 >
-                  <span
-                    className={cn(
-                      "absolute top-5 right-5 flex size-6 items-center justify-center rounded-full border transition-all",
-                      checked
-                        ? "border-transparent bg-gradient-to-br from-green-400 to-cyan-500 text-white"
-                        : "border-fd-border text-transparent group-hover:border-fd-muted-foreground/50",
-                    )}
-                  >
-                    <Check className="size-3.5" strokeWidth={3} />
-                  </span>
-                  <div className="flex items-start gap-4 pe-10">
-                    <IconTile>{feature.icon}</IconTile>
-                    <div className="min-w-0">
-                      <h2
-                        className={cn(
-                          "font-semibold text-lg transition-colors",
-                          !checked && "text-fd-muted-foreground",
-                        )}
-                      >
-                        {feature.title}
-                      </h2>
-                      <p className="mt-1 text-sm text-fd-muted-foreground">
-                        {feature.description}
-                      </p>
-                      <div className="mt-3 flex flex-wrap gap-1.5">
-                        {feature.permissions.map((permission) => (
-                          <Chip key={permission.name} muted={!checked}>
-                            {permission.name}
-                          </Chip>
-                        ))}
-                      </div>
-                    </div>
+                  <div className="flex items-center justify-between gap-3">
+                    <h2
+                      className={cn(
+                        "font-semibold transition-colors",
+                        !checked && "text-fd-muted-foreground",
+                      )}
+                    >
+                      {feature.title}
+                    </h2>
+                    <Checkbox checked={checked} />
+                  </div>
+                  <p className="mt-1 text-fd-muted-foreground text-sm">
+                    {feature.description}
+                  </p>
+                  <div className="mt-3 flex flex-wrap gap-1.5">
+                    {feature.permissions.map((permission) => (
+                      <Chip key={permission.name} muted={!checked}>
+                        {permission.name}
+                      </Chip>
+                    ))}
                   </div>
                 </button>
               );
@@ -256,29 +236,23 @@ export function InvitePicker() {
           </div>
         </>
       ) : (
-        <div className="rounded-2xl border bg-fd-card/60 p-8 backdrop-blur">
-          <div className="flex items-start gap-4">
-            <IconTile>
-              <User />
-            </IconTile>
-            <div>
-              <h2 className="font-semibold text-lg">跟著你走，不用進伺服器</h2>
-              <p className="mt-2 text-fd-muted-foreground">
-                裝在自己的 Discord
-                帳號上，私訊、群組、任何伺服器都能叫出機器龍。
-                發起投票、查個人卡片、玩找吃的，走到哪用到哪。
-              </p>
-              <p className="mt-2 text-fd-muted-foreground">
-                這個模式碰不到伺服器設定，所以一個權限都不用給。
-              </p>
-              <div className="mt-4 flex flex-wrap gap-1.5">
-                {["/poll", "/profile", "/find-food", "/pick", "/bullshit"].map(
-                  (command) => (
-                    <Chip key={command}>{command}</Chip>
-                  ),
-                )}
-              </div>
-            </div>
+        <div className="rounded-xl border bg-fd-card p-6">
+          <h2 className="font-semibold">跟著你走，不用進伺服器</h2>
+          <p className="mt-2 text-fd-muted-foreground text-sm">
+            裝在自己的 Discord
+            帳號上，私訊、群組、任何伺服器都能叫出機器龍。發起投票、查個人卡片、玩找吃的，走到哪用到哪。
+          </p>
+          <p className="mt-2 text-fd-muted-foreground text-sm">
+            這個模式碰不到伺服器設定，所以一個權限都不用給。
+          </p>
+          <div className="mt-4 flex flex-wrap gap-1.5">
+            {["/poll", "/profile", "/find-food", "/pick", "/bullshit"].map(
+              (command) => (
+                <Chip key={command} className="font-mono">
+                  {command}
+                </Chip>
+              ),
+            )}
           </div>
         </div>
       )}
@@ -288,11 +262,11 @@ export function InvitePicker() {
         target="_blank"
         rel="noreferrer"
         className={cn(
-          "mx-auto rounded-xl bg-gradient-to-r from-green-400 to-cyan-500 px-10 py-3.5 font-bold text-white transition-transform hover:scale-[1.03] active:scale-[0.98]",
-          "shadow-[0_8px_40px_-8px] shadow-green-400/50",
+          buttonVariants({ color: "primary", size: "lg" }),
+          "mx-auto px-10",
         )}
       >
-        {mode === "guild" ? "帶我回家 →" : "安裝到我的帳號 →"}
+        {mode === "guild" ? "帶我回家" : "安裝到我的帳號"}
       </a>
     </div>
   );

--- a/src/components/invite/picker.tsx
+++ b/src/components/invite/picker.tsx
@@ -1,0 +1,247 @@
+"use client";
+
+import {
+  AudioLines,
+  Server,
+  Shield,
+  Target,
+  Ticket,
+  Trash2,
+  User,
+  UsersRound,
+} from "lucide-react";
+import { useState, type ReactNode } from "react";
+import { cn } from "@/utils/cn";
+
+const CLIENT_ID = "584213384409382953";
+
+const requiredPermissions = [
+  "檢視頻道",
+  "傳送訊息",
+  "閱讀歷史訊息",
+  "嵌入連結",
+  "附加檔案",
+  "使用外部表情符號",
+  "新增反應",
+];
+
+// https://discord.com/developers/docs/topics/permissions
+const requiredBits =
+  (1n << 6n) | // ADD_REACTIONS
+  (1n << 10n) | // VIEW_CHANNEL
+  (1n << 11n) | // SEND_MESSAGES
+  (1n << 14n) | // EMBED_LINKS
+  (1n << 15n) | // ATTACH_FILES
+  (1n << 16n) | // READ_MESSAGE_HISTORY
+  (1n << 18n); // USE_EXTERNAL_EMOJIS
+
+interface Feature {
+  id: string;
+  icon: ReactNode;
+  title: string;
+  description: string;
+  permissions: { name: string; bit: bigint }[];
+}
+
+const features: Feature[] = [
+  {
+    id: "voice",
+    icon: <AudioLines />,
+    title: "動態語音頻道",
+    description: "一個頻道滿足所有人，自動生出專屬語音頻道",
+    permissions: [
+      { name: "管理頻道", bit: 1n << 4n },
+      { name: "連接", bit: 1n << 20n },
+      { name: "移動成員", bit: 1n << 24n },
+    ],
+  },
+  {
+    id: "roles",
+    icon: <UsersRound />,
+    title: "身分組",
+    description: "新成員自動身分組、自助領取選單、頻道密碼鎖",
+    permissions: [{ name: "管理身分組", bit: 1n << 28n }],
+  },
+  {
+    id: "messages",
+    icon: <Trash2 />,
+    title: "訊息管理",
+    description: "大量刪除訊息、清理投票",
+    permissions: [{ name: "管理訊息", bit: 1n << 13n }],
+  },
+  {
+    id: "ticket",
+    icon: <Ticket />,
+    title: "私人頻道",
+    description: "成員一鍵開啟私人討論串聯絡管理員",
+    permissions: [
+      { name: "管理討論串", bit: 1n << 34n },
+      { name: "建立私人討論串", bit: 1n << 36n },
+      { name: "在討論串中傳送訊息", bit: 1n << 38n },
+    ],
+  },
+  {
+    id: "defense",
+    icon: <Shield />,
+    title: "機器人防禦",
+    description: "陷阱頻道、詐騙圖片過濾，自動趕走廣告機器人",
+    permissions: [
+      { name: "封鎖成員", bit: 1n << 2n },
+      { name: "禁言成員", bit: 1n << 40n },
+    ],
+  },
+];
+
+function inviteUrl(mode: "guild" | "user", selected: Set<string>) {
+  if (mode === "user")
+    return `https://discord.com/oauth2/authorize?client_id=${CLIENT_ID}&integration_type=1&scope=applications.commands`;
+
+  let bits = requiredBits;
+
+  for (const feature of features) {
+    if (!selected.has(feature.id)) continue;
+
+    for (const permission of feature.permissions) bits |= permission.bit;
+  }
+
+  return `https://discord.com/oauth2/authorize?client_id=${CLIENT_ID}&scope=bot+applications.commands&permissions=${bits}`;
+}
+
+function Chip({ children }: { children: ReactNode }) {
+  return (
+    <span className="rounded-full bg-fd-muted px-2.5 py-1 text-xs text-fd-muted-foreground">
+      {children}
+    </span>
+  );
+}
+
+export function InvitePicker() {
+  const [mode, setMode] = useState<"guild" | "user">("guild");
+  const [selected, setSelected] = useState(
+    () => new Set(features.map((feature) => feature.id)),
+  );
+
+  function toggle(id: string) {
+    setSelected((current) => {
+      const next = new Set(current);
+
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+
+      return next;
+    });
+  }
+
+  return (
+    <div className="flex flex-col gap-6">
+      <div className="mx-auto flex rounded-lg border bg-fd-card p-1">
+        {(
+          [
+            ["guild", <Server key="i" className="size-4" />, "安裝到伺服器"],
+            ["user", <User key="i" className="size-4" />, "安裝到帳號"],
+          ] as const
+        ).map(([value, icon, label]) => (
+          <button
+            key={value}
+            type="button"
+            onClick={() => setMode(value)}
+            className={cn(
+              "flex items-center gap-2 rounded-md px-4 py-2 text-sm font-medium transition-colors",
+              mode === value
+                ? "bg-fd-primary text-fd-primary-foreground"
+                : "text-fd-muted-foreground hover:text-fd-foreground",
+            )}
+          >
+            {icon}
+            {label}
+          </button>
+        ))}
+      </div>
+
+      {mode === "guild" ? (
+        <>
+          <div className="rounded-xl border bg-fd-card p-5">
+            <div className="flex items-center justify-between gap-4">
+              <div className="flex items-center gap-2 font-semibold">
+                <Target className="size-5 text-fd-primary" />
+                必要權限
+              </div>
+              <span className="rounded-full bg-fd-primary/10 px-2.5 py-1 text-xs font-medium text-fd-primary">
+                必要
+              </span>
+            </div>
+            <p className="mt-2 text-sm text-fd-muted-foreground">
+              讓機器龍能正常運作的基本條件
+            </p>
+            <div className="mt-3 flex flex-wrap gap-2">
+              {requiredPermissions.map((permission) => (
+                <Chip key={permission}>{permission}</Chip>
+              ))}
+            </div>
+          </div>
+
+          <div className="grid gap-4 sm:grid-cols-2">
+            {features.map((feature) => {
+              const checked = selected.has(feature.id);
+
+              return (
+                <button
+                  key={feature.id}
+                  type="button"
+                  onClick={() => toggle(feature.id)}
+                  aria-pressed={checked}
+                  className={cn(
+                    "rounded-xl border p-5 text-left transition-colors",
+                    checked
+                      ? "border-fd-primary/50 bg-fd-card"
+                      : "bg-fd-card/50 opacity-60 hover:opacity-90",
+                  )}
+                >
+                  <div className="flex items-center justify-between gap-4">
+                    <div className="flex items-center gap-2 font-semibold [&_svg]:size-5 [&_svg]:text-fd-primary">
+                      {feature.icon}
+                      {feature.title}
+                    </div>
+                    <span
+                      className={cn(
+                        "flex size-5 items-center justify-center rounded border text-xs",
+                        checked
+                          ? "border-fd-primary bg-fd-primary text-fd-primary-foreground"
+                          : "border-fd-border",
+                      )}
+                    >
+                      {checked ? "✓" : ""}
+                    </span>
+                  </div>
+                  <p className="mt-2 text-sm text-fd-muted-foreground">
+                    {feature.description}
+                  </p>
+                  <div className="mt-3 flex flex-wrap gap-2">
+                    {feature.permissions.map((permission) => (
+                      <Chip key={permission.name}>{permission.name}</Chip>
+                    ))}
+                  </div>
+                </button>
+              );
+            })}
+          </div>
+        </>
+      ) : (
+        <div className="rounded-xl border bg-fd-card p-6 text-center text-sm text-fd-muted-foreground">
+          裝在你自己的 Discord 帳號上，不用進伺服器也能用。
+          <br />
+          投票、個人資訊這些指令在私訊、群組私訊、任何伺服器都能使用，不需要任何權限。
+        </div>
+      )}
+
+      <a
+        href={inviteUrl(mode, selected)}
+        target="_blank"
+        rel="noreferrer"
+        className="mx-auto rounded-lg bg-fd-primary px-8 py-3 font-semibold text-fd-primary-foreground transition-opacity hover:opacity-90"
+      >
+        邀請機器龍 →
+      </a>
+    </div>
+  );
+}

--- a/src/components/invite/picker.tsx
+++ b/src/components/invite/picker.tsx
@@ -2,9 +2,10 @@
 
 import {
   AudioLines,
+  Check,
   Server,
-  Shield,
-  Target,
+  ShieldCheck,
+  Sparkles,
   Ticket,
   Trash2,
   User,
@@ -48,7 +49,7 @@ const features: Feature[] = [
     id: "voice",
     icon: <AudioLines />,
     title: "動態語音頻道",
-    description: "一個頻道滿足所有人，自動生出專屬語音頻道",
+    description: "有人進語音就開一間專屬房間，人走了自動收。",
     permissions: [
       { name: "管理頻道", bit: 1n << 4n },
       { name: "連接", bit: 1n << 20n },
@@ -59,21 +60,21 @@ const features: Feature[] = [
     id: "roles",
     icon: <UsersRound />,
     title: "身分組",
-    description: "新成員自動身分組、自助領取選單、頻道密碼鎖",
+    description: "新成員進來自動發，或讓成員自己按按鈕領。",
     permissions: [{ name: "管理身分組", bit: 1n << 28n }],
   },
   {
     id: "messages",
     icon: <Trash2 />,
     title: "訊息管理",
-    description: "大量刪除訊息、清理投票",
+    description: "洗版訊息一次清掉，最多一千則。",
     permissions: [{ name: "管理訊息", bit: 1n << 13n }],
   },
   {
     id: "ticket",
     icon: <Ticket />,
     title: "私人頻道",
-    description: "成員一鍵開啟私人討論串聯絡管理員",
+    description: "成員按一顆按鈕，就能私下找管理員。",
     permissions: [
       { name: "管理討論串", bit: 1n << 34n },
       { name: "建立私人討論串", bit: 1n << 36n },
@@ -82,9 +83,9 @@ const features: Feature[] = [
   },
   {
     id: "defense",
-    icon: <Shield />,
+    icon: <ShieldCheck />,
     title: "機器人防禦",
-    description: "陷阱頻道、詐騙圖片過濾，自動趕走廣告機器人",
+    description: "廣告機器人一發言就封鎖，詐騙圖片自動攔下。",
     permissions: [
       { name: "封鎖成員", bit: 1n << 2n },
       { name: "禁言成員", bit: 1n << 40n },
@@ -107,9 +108,24 @@ function inviteUrl(mode: "guild" | "user", selected: Set<string>) {
   return `https://discord.com/oauth2/authorize?client_id=${CLIENT_ID}&scope=bot+applications.commands&permissions=${bits}`;
 }
 
-function Chip({ children }: { children: ReactNode }) {
+function Chip({ muted, children }: { muted?: boolean; children: ReactNode }) {
   return (
-    <span className="rounded-full bg-fd-muted px-2.5 py-1 text-xs text-fd-muted-foreground">
+    <span
+      className={cn(
+        "rounded-md border px-2 py-0.5 text-xs transition-colors",
+        muted
+          ? "border-fd-border/50 text-fd-muted-foreground/50"
+          : "text-fd-muted-foreground",
+      )}
+    >
+      {children}
+    </span>
+  );
+}
+
+function IconTile({ children }: { children: ReactNode }) {
+  return (
+    <span className="flex size-10 shrink-0 items-center justify-center rounded-lg bg-gradient-to-br from-green-400/15 to-cyan-500/15 text-green-500 [&_svg]:size-5 dark:text-green-400">
       {children}
     </span>
   );
@@ -133,12 +149,12 @@ export function InvitePicker() {
   }
 
   return (
-    <div className="flex flex-col gap-6">
-      <div className="mx-auto flex rounded-lg border bg-fd-card p-1">
+    <div className="flex flex-col gap-8">
+      <div className="mx-auto flex rounded-full border bg-fd-muted/50 p-1 text-sm font-medium">
         {(
           [
-            ["guild", <Server key="i" className="size-4" />, "安裝到伺服器"],
-            ["user", <User key="i" className="size-4" />, "安裝到帳號"],
+            ["guild", <Server key="i" className="size-4" />, "裝進伺服器"],
+            ["user", <User key="i" className="size-4" />, "裝到我的帳號"],
           ] as const
         ).map(([value, icon, label]) => (
           <button
@@ -146,9 +162,9 @@ export function InvitePicker() {
             type="button"
             onClick={() => setMode(value)}
             className={cn(
-              "flex items-center gap-2 rounded-md px-4 py-2 text-sm font-medium transition-colors",
+              "flex items-center gap-2 rounded-full px-5 py-2 transition-all",
               mode === value
-                ? "bg-fd-primary text-fd-primary-foreground"
+                ? "bg-fd-background text-fd-foreground shadow-sm"
                 : "text-fd-muted-foreground hover:text-fd-foreground",
             )}
           >
@@ -160,23 +176,27 @@ export function InvitePicker() {
 
       {mode === "guild" ? (
         <>
-          <div className="rounded-xl border bg-fd-card p-5">
-            <div className="flex items-center justify-between gap-4">
-              <div className="flex items-center gap-2 font-semibold">
-                <Target className="size-5 text-fd-primary" />
-                必要權限
+          <div className="rounded-2xl border bg-fd-card/60 p-6 backdrop-blur">
+            <div className="flex items-start gap-4">
+              <IconTile>
+                <Sparkles />
+              </IconTile>
+              <div className="min-w-0">
+                <div className="flex flex-wrap items-center gap-3">
+                  <h2 className="font-semibold text-lg">必要權限</h2>
+                  <span className="rounded-full bg-green-400/10 px-2.5 py-0.5 text-xs font-medium text-green-500 dark:text-green-400">
+                    一定要帶
+                  </span>
+                </div>
+                <p className="mt-1 text-sm text-fd-muted-foreground">
+                  看得到頻道、說得了話。少了這些，機器龍進來也只能當雕像。
+                </p>
+                <div className="mt-3 flex flex-wrap gap-1.5">
+                  {requiredPermissions.map((permission) => (
+                    <Chip key={permission}>{permission}</Chip>
+                  ))}
+                </div>
               </div>
-              <span className="rounded-full bg-fd-primary/10 px-2.5 py-1 text-xs font-medium text-fd-primary">
-                必要
-              </span>
-            </div>
-            <p className="mt-2 text-sm text-fd-muted-foreground">
-              讓機器龍能正常運作的基本條件
-            </p>
-            <div className="mt-3 flex flex-wrap gap-2">
-              {requiredPermissions.map((permission) => (
-                <Chip key={permission}>{permission}</Chip>
-              ))}
             </div>
           </div>
 
@@ -191,35 +211,44 @@ export function InvitePicker() {
                   onClick={() => toggle(feature.id)}
                   aria-pressed={checked}
                   className={cn(
-                    "rounded-xl border p-5 text-left transition-colors",
+                    "group relative rounded-2xl border p-6 text-left transition-all duration-200",
                     checked
-                      ? "border-fd-primary/50 bg-fd-card"
-                      : "bg-fd-card/50 opacity-60 hover:opacity-90",
+                      ? "border-green-400/40 bg-gradient-to-br from-green-400/[0.07] to-cyan-500/[0.07] shadow-[0_0_30px_-12px] shadow-green-400/40"
+                      : "bg-fd-card/40 hover:border-fd-muted-foreground/30",
                   )}
                 >
-                  <div className="flex items-center justify-between gap-4">
-                    <div className="flex items-center gap-2 font-semibold [&_svg]:size-5 [&_svg]:text-fd-primary">
-                      {feature.icon}
-                      {feature.title}
+                  <span
+                    className={cn(
+                      "absolute top-5 right-5 flex size-6 items-center justify-center rounded-full border transition-all",
+                      checked
+                        ? "border-transparent bg-gradient-to-br from-green-400 to-cyan-500 text-white"
+                        : "border-fd-border text-transparent group-hover:border-fd-muted-foreground/50",
+                    )}
+                  >
+                    <Check className="size-3.5" strokeWidth={3} />
+                  </span>
+                  <div className="flex items-start gap-4 pe-10">
+                    <IconTile>{feature.icon}</IconTile>
+                    <div className="min-w-0">
+                      <h2
+                        className={cn(
+                          "font-semibold text-lg transition-colors",
+                          !checked && "text-fd-muted-foreground",
+                        )}
+                      >
+                        {feature.title}
+                      </h2>
+                      <p className="mt-1 text-sm text-fd-muted-foreground">
+                        {feature.description}
+                      </p>
+                      <div className="mt-3 flex flex-wrap gap-1.5">
+                        {feature.permissions.map((permission) => (
+                          <Chip key={permission.name} muted={!checked}>
+                            {permission.name}
+                          </Chip>
+                        ))}
+                      </div>
                     </div>
-                    <span
-                      className={cn(
-                        "flex size-5 items-center justify-center rounded border text-xs",
-                        checked
-                          ? "border-fd-primary bg-fd-primary text-fd-primary-foreground"
-                          : "border-fd-border",
-                      )}
-                    >
-                      {checked ? "✓" : ""}
-                    </span>
-                  </div>
-                  <p className="mt-2 text-sm text-fd-muted-foreground">
-                    {feature.description}
-                  </p>
-                  <div className="mt-3 flex flex-wrap gap-2">
-                    {feature.permissions.map((permission) => (
-                      <Chip key={permission.name}>{permission.name}</Chip>
-                    ))}
                   </div>
                 </button>
               );
@@ -227,10 +256,30 @@ export function InvitePicker() {
           </div>
         </>
       ) : (
-        <div className="rounded-xl border bg-fd-card p-6 text-center text-sm text-fd-muted-foreground">
-          裝在你自己的 Discord 帳號上，不用進伺服器也能用。
-          <br />
-          投票、個人資訊這些指令在私訊、群組私訊、任何伺服器都能使用，不需要任何權限。
+        <div className="rounded-2xl border bg-fd-card/60 p-8 backdrop-blur">
+          <div className="flex items-start gap-4">
+            <IconTile>
+              <User />
+            </IconTile>
+            <div>
+              <h2 className="font-semibold text-lg">跟著你走，不用進伺服器</h2>
+              <p className="mt-2 text-fd-muted-foreground">
+                裝在自己的 Discord
+                帳號上，私訊、群組、任何伺服器都能叫出機器龍。
+                發起投票、查個人卡片、玩找吃的，走到哪用到哪。
+              </p>
+              <p className="mt-2 text-fd-muted-foreground">
+                這個模式碰不到伺服器設定，所以一個權限都不用給。
+              </p>
+              <div className="mt-4 flex flex-wrap gap-1.5">
+                {["/poll", "/profile", "/find-food", "/pick", "/bullshit"].map(
+                  (command) => (
+                    <Chip key={command}>{command}</Chip>
+                  ),
+                )}
+              </div>
+            </div>
+          </div>
         </div>
       )}
 
@@ -238,9 +287,12 @@ export function InvitePicker() {
         href={inviteUrl(mode, selected)}
         target="_blank"
         rel="noreferrer"
-        className="mx-auto rounded-lg bg-fd-primary px-8 py-3 font-semibold text-fd-primary-foreground transition-opacity hover:opacity-90"
+        className={cn(
+          "mx-auto rounded-xl bg-gradient-to-r from-green-400 to-cyan-500 px-10 py-3.5 font-bold text-white transition-transform hover:scale-[1.03] active:scale-[0.98]",
+          "shadow-[0_8px_40px_-8px] shadow-green-400/50",
+        )}
       >
-        邀請機器龍 →
+        {mode === "guild" ? "帶我回家 →" : "安裝到我的帳號 →"}
       </a>
     </div>
   );

--- a/src/home/Hero.tsx
+++ b/src/home/Hero.tsx
@@ -1,7 +1,6 @@
 const HeroGradient = "/hero.svg";
 import clsx from "clsx";
 import Link from "fumadocs-core/link";
-import { ExternalLinkIcon } from "lucide-react";
 import { buttonVariants } from "@/components/ui/button";
 import { cn } from "@/utils/cn";
 import Gradient from "./components/Gradient";
@@ -89,8 +88,7 @@ function Buttons() {
         使用教學
       </Link>
       <Link
-        href="https://app.yeecord.com/invite"
-        target="_blank"
+        href="/invite"
         className={cn(
           buttonVariants({
             color: "secondary",
@@ -98,7 +96,6 @@ function Buttons() {
           }),
         )}
       >
-        <ExternalLinkIcon className="size-5" />
         邀請機器人
       </Link>
     </div>

--- a/src/pages/invite.tsx
+++ b/src/pages/invite.tsx
@@ -2,11 +2,12 @@ import { HomeLayout } from "fumadocs-ui/layouts/home";
 import Footer from "@/components/Footer";
 import { footer, domain } from "@config";
 import { InvitePicker } from "@/components/invite/picker";
+import Gradient from "@/home/components/Gradient";
 import { baseOptions } from "@/layout-config";
 
 const TITLE = "邀請 YEE 式機器龍";
 const DESCRIPTION =
-  "自由勾選要授予機器龍的權限，或是安裝到自己的帳號上到處使用。";
+  "權限自己勾，勾多少拿多少。也可以裝到自己的帳號上，私訊和任何伺服器都能用。";
 
 export default function InvitePage() {
   return (
@@ -16,10 +17,42 @@ export default function InvitePage() {
       <link rel="canonical" href={`${domain}/invite`} />
       <meta property="og:title" content={TITLE} />
       <meta property="og:description" content={DESCRIPTION} />
-      <main className="mx-auto w-full max-w-4xl px-4 py-16">
-        <h1 className="text-center font-bold text-4xl">快來把我帶回家！</h1>
-        <p className="mt-4 mb-10 text-center text-fd-muted-foreground">
-          勾選你需要的功能，機器龍只會拿走該拿的權限
+      <main className="relative mx-auto w-full max-w-4xl overflow-x-clip px-4 pt-20 pb-24">
+        <Gradient
+          src="/hero.svg"
+          className="-top-[250px] -z-[1] absolute right-[-20%] hidden w-full min-w-[700px] opacity-70 md:block"
+        />
+        <div className="mb-6 flex items-center justify-center gap-4">
+          <img
+            src="/img/logo.png"
+            alt="YEE 式機器龍"
+            width={72}
+            height={72}
+            className="rounded-full shadow-[0_0_40px_-8px] shadow-green-400/60"
+          />
+          <span className="text-2xl text-fd-muted-foreground tracking-[0.4em]">
+            ⋯
+          </span>
+          <span className="flex size-[72px] items-center justify-center rounded-full bg-discord-blurple shadow-[0_0_40px_-8px] shadow-discord-blurple/55">
+            <svg
+              viewBox="0 0 24 24"
+              fill="white"
+              className="size-10"
+              aria-label="Discord"
+            >
+              <path d="M20.317 4.3698a19.7913 19.7913 0 00-4.8851-1.5152.0741.0741 0 00-.0785.0371c-.211.3753-.4447.8648-.6083 1.2495-1.8447-.2762-3.68-.2762-5.4868 0-.1636-.3933-.4058-.8742-.6177-1.2495a.077.077 0 00-.0785-.037 19.7363 19.7363 0 00-4.8852 1.515.0699.0699 0 00-.0321.0277C.5334 9.0458-.319 13.5799.0992 18.0578a.0824.0824 0 00.0312.0561c2.0528 1.5076 4.0413 2.4228 5.9929 3.0294a.0777.0777 0 00.0842-.0276c.4616-.6304.8731-1.2952 1.226-1.9942a.076.076 0 00-.0416-.1057c-.6528-.2476-1.2743-.5495-1.8722-.8923a.077.077 0 01-.0076-.1277c.1258-.0943.2517-.1923.3718-.2914a.0743.0743 0 01.0776-.0105c3.9278 1.7933 8.18 1.7933 12.0614 0a.0739.0739 0 01.0785.0095c.1202.099.246.1981.3728.2924a.077.077 0 01-.0066.1276 12.2986 12.2986 0 01-1.873.8914.0766.0766 0 00-.0407.1067c.3604.698.7719 1.3628 1.225 1.9932a.076.076 0 00.0842.0286c1.961-.6067 3.9495-1.5219 6.0023-3.0294a.077.077 0 00.0313-.0552c.5004-5.177-.8382-9.6739-3.5485-13.6604a.061.061 0 00-.0312-.0286zM8.02 15.3312c-1.1825 0-2.1569-1.0857-2.1569-2.419 0-1.3332.9555-2.4189 2.157-2.4189 1.2108 0 2.1757 1.0952 2.1568 2.419 0 1.3332-.9555 2.4189-2.1569 2.4189zm7.9748 0c-1.1825 0-2.1569-1.0857-2.1569-2.419 0-1.3332.9554-2.4189 2.1569-2.4189 1.2108 0 2.1757 1.0952 2.1568 2.419 0 1.3332-.946 2.4189-2.1568 2.4189Z" />
+            </svg>
+          </span>
+        </div>
+        <h1 className="text-center font-bold text-4xl sm:text-5xl">
+          快來把我
+          <span className="bg-gradient-to-r from-green-400 to-cyan-500 bg-clip-text text-transparent">
+            帶回家
+          </span>
+          ！
+        </h1>
+        <p className="mx-auto mt-4 mb-12 max-w-md text-center text-fd-muted-foreground text-lg">
+          權限自己勾，勾多少拿多少。不放心的先不給，之後隨時能補。
         </p>
         <InvitePicker />
       </main>

--- a/src/pages/invite.tsx
+++ b/src/pages/invite.tsx
@@ -1,0 +1,35 @@
+import { HomeLayout } from "fumadocs-ui/layouts/home";
+import Footer from "@/components/Footer";
+import { footer, domain } from "@config";
+import { InvitePicker } from "@/components/invite/picker";
+import { baseOptions } from "@/layout-config";
+
+const TITLE = "邀請 YEE 式機器龍";
+const DESCRIPTION =
+  "自由勾選要授予機器龍的權限，或是安裝到自己的帳號上到處使用。";
+
+export default function InvitePage() {
+  return (
+    <HomeLayout {...baseOptions}>
+      <title>{TITLE}</title>
+      <meta name="description" content={DESCRIPTION} />
+      <link rel="canonical" href={`${domain}/invite`} />
+      <meta property="og:title" content={TITLE} />
+      <meta property="og:description" content={DESCRIPTION} />
+      <main className="mx-auto w-full max-w-4xl px-4 py-16">
+        <h1 className="text-center font-bold text-4xl">快來把我帶回家！</h1>
+        <p className="mt-4 mb-10 text-center text-fd-muted-foreground">
+          勾選你需要的功能，機器龍只會拿走該拿的權限
+        </p>
+        <InvitePicker />
+      </main>
+      <Footer categories={footer} />
+    </HomeLayout>
+  );
+}
+
+export function getConfig() {
+  return {
+    render: "static",
+  } as const;
+}

--- a/src/pages/invite.tsx
+++ b/src/pages/invite.tsx
@@ -2,7 +2,6 @@ import { HomeLayout } from "fumadocs-ui/layouts/home";
 import Footer from "@/components/Footer";
 import { footer, domain } from "@config";
 import { InvitePicker } from "@/components/invite/picker";
-import Gradient from "@/home/components/Gradient";
 import { baseOptions } from "@/layout-config";
 
 const TITLE = "邀請 YEE 式機器龍";
@@ -17,27 +16,23 @@ export default function InvitePage() {
       <link rel="canonical" href={`${domain}/invite`} />
       <meta property="og:title" content={TITLE} />
       <meta property="og:description" content={DESCRIPTION} />
-      <main className="relative mx-auto w-full max-w-4xl overflow-x-clip px-4 pt-20 pb-24">
-        <Gradient
-          src="/hero.svg"
-          className="-top-[250px] -z-[1] absolute right-[-20%] hidden w-full min-w-[700px] opacity-70 md:block"
-        />
+      <main className="mx-auto w-full max-w-4xl px-4 pt-20 pb-24">
         <div className="mb-6 flex items-center justify-center gap-4">
           <img
             src="/img/logo.png"
             alt="YEE 式機器龍"
-            width={72}
-            height={72}
-            className="rounded-full shadow-[0_0_40px_-8px] shadow-green-400/60"
+            width={64}
+            height={64}
+            className="rounded-full"
           />
           <span className="text-2xl text-fd-muted-foreground tracking-[0.4em]">
             ⋯
           </span>
-          <span className="flex size-[72px] items-center justify-center rounded-full bg-discord-blurple shadow-[0_0_40px_-8px] shadow-discord-blurple/55">
+          <span className="flex size-16 items-center justify-center rounded-full bg-discord-blurple">
             <svg
               viewBox="0 0 24 24"
               fill="white"
-              className="size-10"
+              className="size-9"
               aria-label="Discord"
             >
               <path d="M20.317 4.3698a19.7913 19.7913 0 00-4.8851-1.5152.0741.0741 0 00-.0785.0371c-.211.3753-.4447.8648-.6083 1.2495-1.8447-.2762-3.68-.2762-5.4868 0-.1636-.3933-.4058-.8742-.6177-1.2495a.077.077 0 00-.0785-.037 19.7363 19.7363 0 00-4.8852 1.515.0699.0699 0 00-.0321.0277C.5334 9.0458-.319 13.5799.0992 18.0578a.0824.0824 0 00.0312.0561c2.0528 1.5076 4.0413 2.4228 5.9929 3.0294a.0777.0777 0 00.0842-.0276c.4616-.6304.8731-1.2952 1.226-1.9942a.076.076 0 00-.0416-.1057c-.6528-.2476-1.2743-.5495-1.8722-.8923a.077.077 0 01-.0076-.1277c.1258-.0943.2517-.1923.3718-.2914a.0743.0743 0 01.0776-.0105c3.9278 1.7933 8.18 1.7933 12.0614 0a.0739.0739 0 01.0785.0095c.1202.099.246.1981.3728.2924a.077.077 0 01-.0066.1276 12.2986 12.2986 0 01-1.873.8914.0766.0766 0 00-.0407.1067c.3604.698.7719 1.3628 1.225 1.9932a.076.076 0 00.0842.0286c1.961-.6067 3.9495-1.5219 6.0023-3.0294a.077.077 0 00.0313-.0552c.5004-5.177-.8382-9.6739-3.5485-13.6604a.061.061 0 00-.0312-.0286zM8.02 15.3312c-1.1825 0-2.1569-1.0857-2.1569-2.419 0-1.3332.9555-2.4189 2.157-2.4189 1.2108 0 2.1757 1.0952 2.1568 2.419 0 1.3332-.9555 2.4189-2.1569 2.4189zm7.9748 0c-1.1825 0-2.1569-1.0857-2.1569-2.419 0-1.3332.9554-2.4189 2.1569-2.4189 1.2108 0 2.1757 1.0952 2.1568 2.419 0 1.3332-.946 2.4189-2.1568 2.4189Z" />
@@ -46,12 +41,9 @@ export default function InvitePage() {
         </div>
         <h1 className="text-center font-bold text-4xl sm:text-5xl">
           快來把我
-          <span className="bg-gradient-to-r from-green-400 to-cyan-500 bg-clip-text text-transparent">
-            帶回家
-          </span>
-          ！
+          <span className="text-green-600 dark:text-green-400">帶回家</span>！
         </h1>
-        <p className="mx-auto mt-4 mb-12 max-w-md text-center text-fd-muted-foreground text-lg">
+        <p className="mx-auto mt-4 mb-10 max-w-md text-center text-fd-muted-foreground text-lg">
           權限自己勾，勾多少拿多少。不放心的先不給，之後隨時能補。
         </p>
         <InvitePicker />


### PR DESCRIPTION
## Why

現在 /invite 直接 302 到 app.yeecord.com 的固定邀請連結，權限是一包全拿。使用者沒辦法只授予自己需要的權限，也沒有帳號安裝（user install）的入口。

## What

- 新增 `/invite` 靜態頁：單頁勾選，不用 step form
  - 「必要權限」固定卡片，列出機器龍運作的基本權限
  - 五張功能卡（動態語音、身分組、訊息管理、私人頻道、機器人防禦）各自對應權限位元，點卡片即勾選，預設全開
  - 底部按鈕依勾選即時組出 Discord OAuth URL（`permissions` 用 BigInt 累加）
- 頂部「安裝到伺服器／安裝到帳號」切換：帳號安裝走 `integration_type=1`，只帶 `applications.commands`，不要求任何權限
- `_redirects`：移除 `/invite` 的外部轉址，`/i`、`/link` 改指向 `/invite`
- 樣式全用 fumadocs 的 `fd-*` token，深淺色自動跟隨

## Notes

- client_id 沿用 `584213384409382953`
- 權限位元對照 Discord 官方文件，必要權限：檢視頻道、傳送訊息、歷史訊息、嵌入連結、附加檔案、外部表情、新增反應