### PR TITLE
point canonical and sitemap urls at trailing-slash form

### DIFF
--- a/config.ts
+++ b/config.ts
@@ -2,6 +2,11 @@ import type { FooterCategory } from "@/components/Footer";
 
 export const domain = "https://yeecord.com";
 
+// Cloudflare Pages 對目錄頁一律 308 到帶斜線網址，canonical 必須指向最終網址
+export function canonicalUrl(path: string) {
+  return `${domain}${path.endsWith("/") ? path : `${path}/`}`;
+}
+
 export const footer: FooterCategory[] = [
   {
     title: "連結",

--- a/press.config.tsx
+++ b/press.config.tsx
@@ -1,5 +1,5 @@
 import { zhTW } from "@fumapress/language/zh-tw";
-import { domain } from "@config";
+import { canonicalUrl, domain } from "@config";
 import { defineTranslations } from "fumadocs-core/i18n";
 import defaultMdxComponents, { createRelativeLink } from "fumadocs-ui/mdx";
 import { i18nProvider, uiTranslations } from "fumadocs-ui/i18n";
@@ -89,7 +89,11 @@ const config = defineConfig({
   )
   .plugins(
     oramaSearchPlugin(),
-    sitemapPlugin(),
+    sitemapPlugin({
+      getEntry(page) {
+        return { loc: canonicalUrl(page.url), priority: 0.8 };
+      },
+    }),
     llmsPlugin(),
     takumiPlugin({
       generate(page) {

--- a/src/blog/layouts.tsx
+++ b/src/blog/layouts.tsx
@@ -1,4 +1,4 @@
-import { blogAuthors, domain, footer, type AuthorData } from "@config";
+import { blogAuthors, canonicalUrl, footer, type AuthorData } from "@config";
 import Link from "fumadocs-core/link";
 import { DocsBody } from "fumadocs-ui/page";
 import { HomeLayout } from "fumadocs-ui/layouts/home";
@@ -53,7 +53,7 @@ function Meta({
   return (
     <>
       <title>{title}</title>
-      <link rel="canonical" href={`${domain}${path}`} />
+      <link rel="canonical" href={canonicalUrl(path)} />
       <meta property="og:title" content={title} />
       {description && <meta name="description" content={description} />}
       {description && <meta property="og:description" content={description} />}

--- a/src/legal-layout.tsx
+++ b/src/legal-layout.tsx
@@ -1,4 +1,4 @@
-import { domain, footer } from "@config";
+import { canonicalUrl, footer } from "@config";
 import { DocsBody } from "fumadocs-ui/page";
 import { HomeLayout } from "fumadocs-ui/layouts/home";
 import { getPressContext } from "fumapress";
@@ -23,7 +23,7 @@ export const LegalPage: FC<{
   return (
     <HomeLayout {...baseOptions}>
       <title>{`Yeecord - ${page.data.title}`}</title>
-      <link rel="canonical" href={`${domain}${page.url}`} />
+      <link rel="canonical" href={canonicalUrl(page.url)} />
       {page.data.description && (
         <meta name="description" content={page.data.description} />
       )}

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,4 +1,4 @@
-import { domain, footer } from "@config";
+import { canonicalUrl, footer } from "@config";
 import { HomeLayout } from "fumadocs-ui/layouts/home";
 import Footer from "@/components/Footer";
 import { Community } from "@/home/Community";
@@ -18,7 +18,7 @@ export default function HomePage() {
     <HomeLayout {...baseOptions}>
       <title>{TITLE}</title>
       <meta name="description" content={DESCRIPTION} />
-      <link rel="canonical" href={domain} />
+      <link rel="canonical" href={canonicalUrl("/")} />
       <meta property="og:title" content={TITLE} />
       <meta property="og:description" content={DESCRIPTION} />
       <meta property="og:image" content="/opengraph-image.png" />


### PR DESCRIPTION
## Why

Cloudflare Pages 對目錄型頁面一律 308 到帶斜線的網址（`/docs` → `/docs/`），但站上的 canonical 跟 sitemap 全部寫成無斜線版本。實測正式站：

```
GET /blog/how-to-invite-bot        → 308 → /blog/how-to-invite-bot/
canonical: https://yeecord.com/blog/how-to-invite-bot   ← 指向一個會轉址的網址
sitemap:   <loc>https://yeecord.com/docs/commands</loc> ← 每條都要多跳一次
```

canonical 指向轉址目標會讓搜尋引擎多解析一層，也可能被當成訊號不一致。

## What

- `config.ts` 新增 `canonicalUrl(path)`：補上結尾斜線再接網域
- 三個 canonical 來源改用它：blog 的 `Meta`、legal 頁、首頁
- `sitemapPlugin` 傳入 `getEntry`，`loc` 一律帶斜線（正式站的 sitemap 本來就沒有 lastmod，行為無損）

建置驗證：blog／legal／首頁 canonical 與 sitemap 全部輸出帶斜線網址。