### PR TITLE
feat: improve CommandHeader link styling and accessibility

### DIFF
--- a/src/components/mdx/command-header.tsx
+++ b/src/components/mdx/command-header.tsx
@@ -80,8 +80,14 @@ export function createCommandHeader(locale: "tw" | "cn") {
           label={t.where}
           items={anywhere ? [t.server, t.dm, t.groupDm] : [t.server]}
         />
-        <p className="px-4 py-2 text-xs text-fd-muted-foreground">
-          {t.hint} <a href={t.basicsUrl}>{t.hintLink}</a>
+        <p className="px-4 py-2 text-xs text-muted-foreground">
+          {t.hint}{" "}
+          <a 
+            className="text-foreground underline decoration-primary underline-offset-4 transition-opacity hover:opacity-80" 
+            href={t.basicsUrl}
+          >
+            {t.hintLink}
+          </a>
         </p>
       </div>
     );


### PR DESCRIPTION
## Why

原本 CommandHeader 的權限提示連結只有預設樣式，在黑色和白色主題下都不夠明顯。
此 PR 的用意是希望讓使用者能更清楚地看到「權限說明」連結，提升使用體驗。

## What

- `src/components/mdx/command-header.tsx`：提示區塊的 `<a>` 標籤新增 underline + decoration-primary 樣式，並增加 hover 透明度變化。 (和其他 `<a>` 標籤的樣式一致)

---
| 主題 | 修改後樣式 |
| :--- | :--- |
| **Dark Theme** | <img width="635" alt="Dark Mode" src="https://github.com/user-attachments/assets/d3b1cab6-4587-4602-b0ed-1d426bf70f5f" /> |
| **Light Theme** | <img width="634" alt="Light Mode" src="https://github.com/user-attachments/assets/2b9df056-7cff-4712-9eea-8c35a4be849c" /> |

---
