### PR TITLE
feat: shrink the dino during play, add double jump, ease difficulty

### DIFF
--- a/src/home/DinoGame.tsx
+++ b/src/home/DinoGame.tsx
@@ -260,7 +260,7 @@ export function DinoGame({ locale, alt }: { locale: Locale; alt: string }) {
   useEffect(() => stopLoop, []);
 
   const scorePill =
-    "flex items-baseline gap-2 rounded-full border bg-fd-background/80 px-3 py-1 font-bold font-mono text-sm shadow-sm backdrop-blur";
+    "flex items-baseline gap-2 rounded-full border bg-fd-background/80 px-3 py-1 font-bold font-mono text-sm shadow-sm backdrop-blur animate-in fade-in slide-in-from-bottom-1 duration-200 ease-out motion-reduce:animate-none";
 
   return (
     <>
@@ -283,7 +283,7 @@ export function DinoGame({ locale, alt }: { locale: Locale; alt: string }) {
               draggable={false}
               style={{ height: sprite.height, left: -sprite.height * sprite.ratio }}
               className={cn(
-                "absolute bottom-0 select-none will-change-transform",
+                "absolute bottom-0 select-none transition-opacity duration-200 will-change-transform",
                 plantDim,
                 mode === "over" && "opacity-60",
               )}
@@ -330,7 +330,7 @@ export function DinoGame({ locale, alt }: { locale: Locale; alt: string }) {
                 <button
                   type="button"
                   onClick={start}
-                  className="rounded-full border bg-fd-background/80 px-3 py-1 font-medium text-sm shadow-sm backdrop-blur transition-colors hover:bg-fd-background motion-reduce:hidden"
+                  className="animate-in fade-in slide-in-from-bottom-1 rounded-full border bg-fd-background/80 px-3 py-1 font-medium text-sm shadow-sm backdrop-blur transition-[background-color,transform] duration-150 ease-out hover:bg-fd-background active:scale-[.97] motion-reduce:hidden"
                 >
                   {mode === "idle" ? t("來玩一場") : t("再來一次")}
                 </button>

--- a/src/home/DinoGame.tsx
+++ b/src/home/DinoGame.tsx
@@ -29,8 +29,7 @@ type Sim = {
   y: number;
   vy: number;
   buffered: number;
-  hitboxLeft: number;
-  hitboxRight: number;
+  jumps: number;
   fieldWidth: number;
   items: { id: number; sprite: number; x: number }[];
   nextId: number;
@@ -83,8 +82,15 @@ export function DinoGame({ locale, alt }: { locale: Locale; alt: string }) {
     const current = sim.current;
 
     if (!current) return;
-    if (current.y === 0) current.vy = JUMP_VELOCITY;
-    else current.buffered = JUMP_BUFFER;
+    if (current.y === 0) {
+      current.vy = JUMP_VELOCITY;
+      current.jumps = 1;
+    } else if (current.jumps < 2) {
+      current.vy = JUMP_VELOCITY * 0.92;
+      current.jumps = 2;
+    } else {
+      current.buffered = JUMP_BUFFER;
+    }
   }
 
   function endJump() {
@@ -104,7 +110,7 @@ export function DinoGame({ locale, alt }: { locale: Locale; alt: string }) {
     const dt = Math.min((now - current.last) / 1000, 0.04);
 
     current.last = now;
-    current.speed += dt * 8;
+    current.speed += dt * 7;
     current.score += dt * 10;
     current.buffered -= dt;
 
@@ -113,13 +119,22 @@ export function DinoGame({ locale, alt }: { locale: Locale; alt: string }) {
       current.y = Math.max(0, current.y + current.vy * dt);
       if (current.y === 0) {
         current.vy = 0;
+        current.jumps = 0;
         if (current.buffered > 0) {
           current.vy = JUMP_VELOCITY;
+          current.jumps = 1;
           current.buffered = 0;
         }
       }
     }
     dino.style.transform = `translateY(${-current.y}px)`;
+
+    /* 每幀重量:開場縮小動畫進行中也拿得到正確的碰撞框。
+       translateY 不影響 left/width,跳躍中量也安全 */
+    const fieldLeft = field.getBoundingClientRect().left;
+    const dinoRect = dino.getBoundingClientRect();
+    const hitboxLeft = dinoRect.left - fieldLeft + dinoRect.width * 0.35;
+    const hitboxRight = dinoRect.left - fieldLeft + dinoRect.width * 0.75;
 
     current.spawnIn -= dt;
     if (current.spawnIn <= 0) {
@@ -127,7 +142,7 @@ export function DinoGame({ locale, alt }: { locale: Locale; alt: string }) {
       const sprite = Math.floor(Math.random() * SPRITES.length);
 
       current.items.push({ id, sprite, x: 0 });
-      current.spawnIn = 0.9 + Math.random() * 1.1;
+      current.spawnIn = 1.0 + Math.random() * 1.15;
       setObstacles((list) => [...list, { id, sprite }]);
     }
 
@@ -144,9 +159,9 @@ export function DinoGame({ locale, alt }: { locale: Locale; alt: string }) {
       if (el) el.style.transform = `translateX(${item.x}px)`;
 
       const hit =
-        item.x - width * 0.2 > current.hitboxLeft &&
-        item.x - width * 0.8 < current.hitboxRight &&
-        current.y < height - 6;
+        item.x - width * 0.25 > hitboxLeft &&
+        item.x - width * 0.75 < hitboxRight &&
+        current.y < height - 10;
 
       if (hit) {
         die();
@@ -181,22 +196,18 @@ export function DinoGame({ locale, alt }: { locale: Locale; alt: string }) {
 
     if (!field || !dino) return;
 
-    const fieldRect = field.getBoundingClientRect();
-    const dinoRect = dino.getBoundingClientRect();
-
     sim.current = {
       raf: 0,
       last: performance.now(),
       y: 0,
       vy: 0,
       buffered: 0,
-      hitboxLeft: dinoRect.left - fieldRect.left + dinoRect.width * 0.3,
-      hitboxRight: dinoRect.left - fieldRect.left + dinoRect.width * 0.8,
-      fieldWidth: fieldRect.width,
+      jumps: 0,
+      fieldWidth: field.getBoundingClientRect().width,
       items: [],
       nextId: 1,
-      spawnIn: 1.2,
-      speed: 320,
+      spawnIn: 1.4,
+      speed: 300,
       score: 0,
     };
     setObstacles([]);

--- a/src/home/DinoMascot.tsx
+++ b/src/home/DinoMascot.tsx
@@ -53,8 +53,8 @@ export function DinoMascot({
             src="/img/logo.svg"
             className={
               playing
-                ? "h-28 drop-shadow-lg sm:h-52 lg:h-64"
-                : "h-28 animate-[bob_5s_ease-in-out_infinite] drop-shadow-lg motion-reduce:animate-none sm:h-52 lg:h-64"
+                ? "h-16 drop-shadow-lg transition-[height] duration-300 sm:h-24 lg:h-28"
+                : "h-28 animate-[bob_5s_ease-in-out_infinite] drop-shadow-lg transition-[height] duration-300 motion-reduce:animate-none sm:h-52 lg:h-64"
             }
             draggable={false}
           />

--- a/src/home/DinoMascot.tsx
+++ b/src/home/DinoMascot.tsx
@@ -53,8 +53,8 @@ export function DinoMascot({
             src="/img/logo.svg"
             className={
               playing
-                ? "h-16 drop-shadow-lg transition-[height] duration-300 sm:h-24 lg:h-28"
-                : "h-28 animate-[bob_5s_ease-in-out_infinite] drop-shadow-lg transition-[height] duration-300 motion-reduce:animate-none sm:h-52 lg:h-64"
+                ? "h-16 drop-shadow-lg transition-[height] duration-300 ease-out motion-reduce:transition-none sm:h-24 lg:h-28"
+                : "h-28 animate-[bob_5s_ease-in-out_infinite] drop-shadow-lg transition-[height] duration-300 ease-out motion-reduce:animate-none motion-reduce:transition-none sm:h-52 lg:h-64"
             }
             draggable={false}
           />


### PR DESCRIPTION
## Why
The dino is huge next to the obstacles, so collisions feel unfair. One jump also leaves no way to recover from a mistimed press.

## What
The dino shrinks to game size while playing and grows back after. A second mid-air jump is available, refreshed on landing. The hitbox is measured every frame so the shrink animation never leaves a stale oversized hitbox, collision margins are more forgiving, and the run starts slower with slightly wider obstacle gaps.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 恐龍遊戲新增二段跳；第三次跳躍會暫存，落地後自動執行。
  * 障礙物生成與速度調整，遊戲節奏更平順。
  * 碰撞判定會依恐龍實際位置動態更新。

* **視覺改善**
  * 更新分數徽章、障礙物與操作按鈕的動畫、透明度及互動樣式。
  * 遊戲播放時恐龍吉祥物縮小，並新增平滑高度轉場動畫。
  * 啟用「減少動態效果」偏好時，停用吉祥物高度轉場。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->