### PR TITLE
fix: stop the d key from flipping the theme

### DIFF
--- a/src/root-layout.tsx
+++ b/src/root-layout.tsx
@@ -16,6 +16,9 @@ const BaseRootLayout = createRootLayout({
     search: {
       SearchDialog,
     },
+    theme: {
+      hotKey: false,
+    },
   },
 });
 


### PR DESCRIPTION
## Why

Pressing `d` anywhere outside an input flipped the site between light and dark. Nobody asked for that shortcut; it comes from the `hotKey: "d"` default in fumadocs-ui `RootProvider`.

## What

Pass `theme.hotKey: false` through `providerProps`, which drops the global keydown listener. The theme toggle in the UI still works.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **功能調整**
  * 停用主題切換的快捷鍵，避免意外觸發主題變更。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->