### PR TITLE
docs: 抽獎重抽

### DIFF
--- a/content/docs/commands/giveaway.mdx
+++ b/content/docs/commands/giveaway.mdx
@@ -38,3 +38,7 @@ description: 在伺服器舉辦抽獎活動，可以限制參加資格、設定�
 ## 重新傳送
 
 抽獎訊息被洗版時，用 <Cmd name="giveaway resend" /> 把它重新傳到最下面，`giveaway` 參數有自動補全。
+
+## 重抽得獎者
+
+得獎者棄權或資格不符時，用 <Cmd name="giveaway reroll" /> 從還沒中獎的參加者裡再抽一次，結果會公告在原本的抽獎頻道。`amount_of_winners` 留空只補抽 1 位。只能重抽自己建立、已經結束的抽獎。

--- a/content/docs/commands/giveaway.zh-cn.mdx
+++ b/content/docs/commands/giveaway.zh-cn.mdx
@@ -38,3 +38,7 @@ description: 在服务器举办抽奖活动，可以限制参加资格、设置�
 ## 重新发送
 
 抽奖消息被刷屏时，用 <Cmd name="giveaway resend" /> 把它重新发到最下面，`giveaway` 参数有自动补全。
+
+## 重抽中奖者
+
+中奖者弃权或资格不符时，用 <Cmd name="giveaway reroll" /> 从还没中奖的参加者里再抽一次，结果会公告在原本的抽奖频道。`amount_of_winners` 留空只补抽 1 位。只能重抽自己建立、已经结束的抽奖。


### PR DESCRIPTION
## Why
機器人這批更新加了 `/giveaway reroll`（yeecord/yeecord#143），文件還沒提到。

## What
抽獎頁補「重抽得獎者」一節，說明重抽範圍、預設人數與公告位置，繁簡兩版同步。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **文件**
  * 新增「重抽得獎者」說明，涵蓋得獎者棄權或資格不符時的處理流程。
  * 說明公告位置、預設補抽人數，以及僅能重抽自己建立且已結束的抽獎等限制。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->