### PR TITLE
docs: 成員通知變數與預覽

### DIFF
--- a/content/docs/commands/member-notification.mdx
+++ b/content/docs/commands/member-notification.mdx
@@ -23,13 +23,20 @@ description: 成員加入或離開伺服器時，在指定頻道發送自訂的�
 | 發送頻道 | 通知要發到哪個文字頻道 |
 | 訊息內容 | 最多 2000 字，支援 Markdown |
 
-訊息內容裡可以放 `{user}`，發送時會換成新成員的標記：
+訊息內容裡可以放變數：
+
+| 變數 | 發送時換成 |
+| ---- | ---- |
+| `{user}` | 成員名稱，純文字 |
+| `{mention}` | 標註成員，對方會收到通知 |
 
 <DiscordChat>
   <DiscordMessage>
     <p>歡迎 <span className="rounded bg-discord-pill px-1 text-discord-pill-foreground">@新成員</span> 加入伺服器！先到規則頻道看看吧 🎉</p>
   </DiscordMessage>
 </DiscordChat>
+
+儲存並啟用後，機器龍會用你本人代入變數，回一則只有你看得到的預覽，不用等真的有人進來才能確認。
 
 加入跟離開的訊息分開設定，各跑一次指令就好。
 

--- a/content/docs/commands/member-notification.zh-cn.mdx
+++ b/content/docs/commands/member-notification.zh-cn.mdx
@@ -23,13 +23,20 @@ description: 成员加入或退出服务器时，在指定频道发送自定义�
 | 发送频道 | 通知要发到哪个文字频道 |
 | 消息内容 | 最多 2000 字，支持 Markdown |
 
-消息内容里可以放 `{user}`，发送时会换成新成员的提及：
+消息内容里可以放变量：
+
+| 变量 | 发送时换成 |
+| ---- | ---- |
+| `{user}` | 成员名称，纯文本 |
+| `{mention}` | 标注成员，对方会收到通知 |
 
 <DiscordChat>
   <DiscordMessage>
     <p>欢迎 <span className="rounded bg-discord-pill px-1 text-discord-pill-foreground">@新成员</span> 加入服务器！先到规则频道看看吧 🎉</p>
   </DiscordMessage>
 </DiscordChat>
+
+保存并启用后，机器龙会用你本人代入变量，回一条只有你看得到的预览，不用等真的有人进来才能确认。
 
 加入和退出的消息分开设置，各跑一次命令就好。
 


### PR DESCRIPTION
## Why
機器人加了 `{mention}` 變數和儲存後預覽（yeecord/yeecord#144）；原本文件還把 `{user}` 寫成「會換成標記」，實際上是純文字名稱。

## What
變數改成表格列出 `{user}`（純文字名稱）和 `{mention}`（實際標註），補預覽說明，繁簡同步。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **文件**
  * 更新成员通知說明，新增 `{user}` 與 `{mention}` 變數及其替換方式。
  * 補充啟用儲存後，系統會以使用者本人預覽通知的行為。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->