### PR TITLE
docs: 投票每人多票

### DIFF
--- a/content/docs/commands/poll.mdx
+++ b/content/docs/commands/poll.mdx
@@ -11,7 +11,13 @@ description: 匿名投票、鎖票、開票前保密、身分組權重，投票�
 
 ## 發起投票
 
-<SlashCommand name="poll create" description="發起投票，會跳出表單讓你填內容" />
+<SlashCommand
+  name="poll create"
+  options={[{ name: "max_votes", value: "3" }]}
+  description="發起一場每人最多投 3 個選項的投票，會跳出表單讓你填內容"
+/>
+
+`max_votes` 選填，是每人最多可投的選項數，預設 1（單選）。設了之後投票卡會標出上限，事後也能用 <Cmd name="poll edit" /> 調整。
 
 送出指令後會跳出表單：
 
@@ -38,7 +44,7 @@ description: 匿名投票、鎖票、開票前保密、身分組權重，投票�
 
 | 指令 | 說明 |
 | ---- | ---- |
-| <Cmd name="poll edit" /> | 修改標題、描述、結束時間、圖片，或補開匿名等設定 |
+| <Cmd name="poll edit" /> | 修改標題、描述、結束時間、圖片、每人可投數，或補開匿名等設定 |
 | <Cmd name="poll end" /> | 結束投票 |
 | <Cmd name="poll resend" /> | 重新傳送投票訊息（原本的訊息被洗版時很好用） |
 | <Cmd name="poll remove-vote" /> | 移除某位成員的票 |

--- a/content/docs/commands/poll.zh-cn.mdx
+++ b/content/docs/commands/poll.zh-cn.mdx
@@ -11,7 +11,13 @@ description: 匿名投票、锁票、开票前保密、身份组权重，投票�
 
 ## 发起投票
 
-<SlashCommand name="poll create" description="发起投票，会弹出表单让你填内容" />
+<SlashCommand
+  name="poll create"
+  options={[{ name: "max_votes", value: "3" }]}
+  description="发起一场每人最多投 3 个选项的投票，会弹出表单让你填内容"
+/>
+
+`max_votes` 选填，是每人最多可投的选项数，默认 1（单选）。设了之后投票卡会标出上限，事后也能用 <Cmd name="poll edit" /> 调整。
 
 发送命令后会弹出表单：
 
@@ -38,7 +44,7 @@ description: 匿名投票、锁票、开票前保密、身份组权重，投票�
 
 | 命令 | 说明 |
 | ---- | ---- |
-| <Cmd name="poll edit" /> | 修改标题、描述、结束时间、图片，或补开匿名等设置 |
+| <Cmd name="poll edit" /> | 修改标题、描述、结束时间、图片、每人可投数，或补开匿名等设置 |
 | <Cmd name="poll end" /> | 结束投票 |
 | <Cmd name="poll resend" /> | 重新发送投票消息（原本的消息被刷屏时很好用） |
 | <Cmd name="poll remove-vote" /> | 移除某位成员的票 |


### PR DESCRIPTION
## Why
機器人加了 `/poll create`、`/poll edit` 的 `max_votes` 參數（yeecord/yeecord#145），文件還沒提到。

## What
發起投票一節的範例帶上 `max_votes`，說明預設單選與事後可調整；管理表格補上每人可投數。繁簡同步。