### PR TITLE
docs: 指令總覽加 language

### DIFF
--- a/content/docs/commands/index.mdx
+++ b/content/docs/commands/index.mdx
@@ -30,6 +30,7 @@ index: true
 | [<Cmd name="role-menu" />](./role-menu.mdx) | 自助領取身分組選單 | 管理身分組 |
 | [<Cmd name="member-notification" />](./member-notification.mdx) | 成員加入／離開通知 | 管理伺服器 |
 | [<Cmd name="form" />](./form.mdx) | 表單與回報系統 | 管理頻道 |
+| <Cmd name="language" /> | 這個伺服器要用的語言，有廣東話 | 管理伺服器 |
 
 ## 活動
 

--- a/content/docs/commands/index.zh-cn.mdx
+++ b/content/docs/commands/index.zh-cn.mdx
@@ -30,6 +30,7 @@ index: true
 | [<Cmd name="role-menu" />](./role-menu.mdx) | 自助领取身份组菜单 | 管理身份组 |
 | [<Cmd name="member-notification" />](./member-notification.mdx) | 成员加入／退出通知 | 管理服务器 |
 | [<Cmd name="form" />](./form.mdx) | 表单与回报系统 | 管理频道 |
+| <Cmd name="language" /> | 这个服务器要用的语言，有广东话 | 管理服务器 |
 
 ## 活动
 


### PR DESCRIPTION
對應 yeecord/yeecord#159。伺服器管理表格加一列 `/language`，繁簡兩版。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **文件**
  * 新增 `language` 指令說明，可設定伺服器使用的語言。
  * 註明支援廣東話，並需要「管理伺服器」權限。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->